### PR TITLE
feat: separate admin and client views

### DIFF
--- a/src/address/views/addressDetails.ejs
+++ b/src/address/views/addressDetails.ejs
@@ -1,4 +1,4 @@
-<form class="flex flex-col w-full gap-10 mt-9 mb-15 ml-5 px-32" id="address-form">
+<form class="flex flex-col w-full gap-10 mt-9 mb-15 px-32" id="address-form">
    <div class="flex flex-col gap-5">
         <h1 class="font-semibold text-[20px]"><%= title %></h1>
         <div class="flex flex-col gap-10" id="addresses">
@@ -78,13 +78,18 @@
                 </div>
             </div>
         </div>
+
         <div class="flex flex-row justify-between items-center mt-2">
-            <a href="/addresses" class="font-semibold text-sm bg-brown text-white rounded hover:bg-dark-brown w-[150px] h-10 flex items-center justify-center">
-            Voltar
-            </a>
-            <button type="submit" class="font-medium text-sm text-white bg-light-green w-[150px] h-10 rounded-[5px] cursor-pointer hover:bg-dark-green flex items-center justify-center">
-            Salvar
-            </button>
+            <% if (!isAdmin) { %>
+                <a href="/addresses" class="font-semibold text-sm bg-brown text-white rounded hover:bg-dark-brown w-[150px] h-10 flex items-center justify-center">
+                Voltar
+                </a>
+            <% } %>
+            <div class="flex flex-1 justify-end">
+                <button type="submit" class="font-medium text-sm text-white bg-light-green w-[150px] h-10 rounded-[5px] cursor-pointer hover:bg-dark-green flex items-center justify-center">
+                    Salvar
+                </button>
+            </div>
         </div>
     </div>
 </form>

--- a/src/card/views/cardDetails.ejs
+++ b/src/card/views/cardDetails.ejs
@@ -42,12 +42,17 @@
             </div>
         </div>
         <div class="flex flex-row justify-between items-center mt-2">
-            <a href="/cards" class="font-semibold text-sm bg-brown text-white rounded hover:bg-dark-brown w-[150px] h-10 flex items-center justify-center">
-            Voltar
+            <% if (!isAdmin) { %>
+                <a href="/cards" class="font-semibold text-sm bg-brown text-white rounded hover:bg-dark-brown w-[150px] h-10 flex items-center justify-center">
+                    Voltar
+                </a>
+            <% } %>
             </a>
-            <button type="submit" class="font-medium text-sm text-white bg-light-green w-[150px] h-10 rounded-[5px] cursor-pointer hover:bg-dark-green flex items-center justify-center">
-            Salvar
-            </button>
+            <div class="flex flex-1 justify-end">
+                <button type="submit" class="font-medium text-sm text-white bg-light-green w-[150px] h-10 rounded-[5px] cursor-pointer hover:bg-dark-green flex items-center justify-center">
+                    Salvar
+                </button>
+            </div>
         </div>
     </div>
 </form>

--- a/src/client/router/clientRouter.ts
+++ b/src/client/router/clientRouter.ts
@@ -25,6 +25,15 @@ clientRouter.get("/admin", async (req: Request, res: Response) => {
 	});
 });
 
+clientRouter.get("/admin/:id", async (req: Request, res: Response) => {
+	res.render("clientDetailsAdmin", {
+		title: "Detalhes do Cliente",
+		currentHeaderTab: "profile",
+		layout: "defaultLayoutAdmin",
+		currentUrl: "clients"
+	});
+});
+
 clientRouter.get("/register", (req: Request, res: Response) => {
 	res.render("clientRegistration", {
 		title: "Cadastro de Clientes",

--- a/src/client/router/clientRouter.ts
+++ b/src/client/router/clientRouter.ts
@@ -3,6 +3,7 @@ import ClientController from "../controller/ClientController";
 import { ClientControllerFactory } from "../factories/ClientControllerFactory";
 import ConfigDynamicPaths from "../../generic/helpers/ConfigDynamicPaths";
 import path from "path";
+import { createSecureContext } from "tls";
 
 const clientRouter = Router();
 clientRouter.use(
@@ -15,10 +16,12 @@ clientRouter.post("/", async (req: Request, res: Response) => {
 	await clientController.create(req, res);
 });
 
-clientRouter.get("/", async (req: Request, res: Response) => {
+clientRouter.get("/admin", async (req: Request, res: Response) => {
 	res.render("clientTable", {
 		title: "Lista de Clientes",
 		currentHeaderTab: "profile",
+		layout: "defaultLayoutAdmin",
+		currentUrl: "clients"
 	});
 });
 

--- a/src/client/views/clientDetails.ejs
+++ b/src/client/views/clientDetails.ejs
@@ -1,4 +1,4 @@
-<form class="flex flex-col w-full gap-10 mt-9 mb-15 px-32" id="client-register-form">
+<form class="flex flex-col w-full gap-10 mt-9 mb-10 px-32" id="client-register-form">
     <div class="flex flex-col gap-4">
         <h1 class="font-semibold text-[20px]">Informações Pessoais</h1>
         <div class="flex flex-row gap-10">

--- a/src/client/views/clientDetailsAdmin.ejs
+++ b/src/client/views/clientDetailsAdmin.ejs
@@ -1,0 +1,13 @@
+<div class="flex flex-col w-full mt-9">
+    <div class="flex justify-between align-middle gap-10 mb-5 px-32">
+        <h1 class="font-semibold text-[20px]">Detalhes do Cliente: José da Silva</h1>
+    </div>
+    <%- include('../../client/views/clientDetails.ejs', {title: "Informações Pessoais", currentUrl: "client"}) %>
+ 
+    <%- include('../../client/views/passwordDetail.ejs', {title: "Alterar Senha"}) %>
+   
+    <%- include('../../address/views/addressDetails.ejs', {title: "Endereços", isAdmin: true}) %>
+
+    <%- include('../../card/views/cardDetails.ejs', {title: "Cartões de Crédito", currentUrl: "card", isAdmin: true}) %>
+</div>
+<script src="/scripts/handleSubmit.mjs"></script>

--- a/src/client/views/clientTable.ejs
+++ b/src/client/views/clientTable.ejs
@@ -28,10 +28,10 @@
                 <td class="px-6 py-3">José da Silva</td>
                 <td class="px-6 py-3">jose123@hotmail.com</td>
                 <td class="px-6 py-3 flex gap-2">
-                    <a href="/clients/id" class="hover:text-gray flex justify-center items-center">
+                    <a href="/clients/admin/id" class="hover:text-gray flex justify-center items-center">
                         <span class="material-symbols-outlined text-base">visibility</span>
                     </a>
-                    <a href="/cards/delete/id" class="hover:text-gray flex justify-center items-center delete-btn">
+                    <a href="/clients/delete/id" class="hover:text-gray flex justify-center items-center delete-btn">
                         <span class="material-symbols-outlined text-base">delete</span>
                     </a>
                 </td>

--- a/src/client/views/clientTable.ejs
+++ b/src/client/views/clientTable.ejs
@@ -1,34 +1,38 @@
-<div class="mt-10">
-    <%- include("headers/detailsHeader.ejs", { pageTitle: "Listagem de Clientes" }) %>
-</div>
-<div class="flex flex-col w-full gap-8 mt-7 mb-12 px-32">
-    <div class="flex justify-between items-center">
-        <h1 class="font-semibold text-[16px]">Clientes (1)</h1>
-        <a href="/clients/register" class="flex items-center gap-1 px-4 py-1 bg-brown text-white rounded hover:bg-dark-brown text-[14px] h-8">
-            <span class="material-symbols-outlined text-[18px]">add</span>
-            <span class="font-semibold">Adicionar</span>
-        </a>
+<div class="flex flex-col w-full gap-10 mt-9 mb-15 px-32">
+    <div class="flex justify-between align-middle">
+        <h1 class="font-semibold text-[20px]">Clientes (1)</h1>
+        <div class="flex items-center gap-4 justify-center">
+            <h1 class="text-gray whitespace-nowrap">Filtrar: </h1>
+            <select class="border border-gray rounded-md px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-dark-brown">
+                <option value="all">Todos</option>
+                <option value="active">Ativos</option>
+                <option value="inactive">Inativos</option>
+            </select>
+            <a href="/clients/register" class="flex items-center gap-1 bg-brown text-white rounded hover:bg-dark-brown text-[14px] h-8 px-2 self-center">
+                <span class="material-symbols-outlined text-[18px]">add</span>
+            </a>
+        </div>
     </div>
-    <table class="w-full border-separate">
-        <thead>
-            <tr class="bg-dark-brown text-white text-center">
-            <th class="px-4 py-2 rounded-l-xl font-semibold text-[14px]">id</th>
-            <th class="px-4 py-2 font-semibold text-[14px]">Nome</th>
-            <th class="px-4 py-2 font-semibold text-[14px]">Email</th>
-            <th class="px-4 py-2 rounded-r-xl font-semibold"></th>
+    <table class="min-w-full border-none rounded-lg overflow-hidden shadow-md">
+        <thead class="bg-dark-brown text-white text-sm uppercase">
+            <tr>
+                <th class="px-6 py-3 text-left font-semibold">ID</th>
+                <th class="px-6 py-3 text-left font-semibold">Nome</th>
+                <th class="px-6 py-3 text-left font-semibold">Email</th>
+                <th class="px-6 py-3 text-left font-semibold">Ações</th>
             </tr>
         </thead>
-        <tbody>
-            <tr class="bg-lighter-brown h-8 border border-dark-brown text-center align-middle">
-                <td class="px-4 py-2 border-r border-dark-brown rounded-l-xl text-[13px]">1</td>
-                <td class="px-4 py-2 border-r border-dark-brown text-[13px]">José da Silva</td>
-                <td class="px-4 py-2 border-r border-dark-brown text-[13px]">jose123@hotmail.com</td>
-                <td class="px-4 py-2 rounded-r-xl flex gap-2 justify-center">
-                    <a href="/clients/id" class="hover:text-gray flex justify-center items-center text-[16px] h-6 w-6">
-                        <span class="material-symbols-outlined text-[16px]">visibility</span>
+        <tbody class="divide-y divide-light-brown text-sm text-gray-2 bg-lighter-brown">
+            <tr>
+                <td class="px-6 py-3 font-medium text-gray-2">1</td>
+                <td class="px-6 py-3">José da Silva</td>
+                <td class="px-6 py-3">jose123@hotmail.com</td>
+                <td class="px-6 py-3 flex gap-2">
+                    <a href="/clients/id" class="hover:text-gray flex justify-center items-center">
+                        <span class="material-symbols-outlined text-base">visibility</span>
                     </a>
-                    <a href="/cards/delete/id" class="hover:text-gray flex justify-center items-center delete-btn text-[16px] h-6 w-6">
-                        <span class="material-symbols-outlined text-[16px]">delete</span>
+                    <a href="/cards/delete/id" class="hover:text-gray flex justify-center items-center delete-btn">
+                        <span class="material-symbols-outlined text-base">delete</span>
                     </a>
                 </td>
             </tr>

--- a/src/client/views/passwordDetail.ejs
+++ b/src/client/views/passwordDetail.ejs
@@ -1,4 +1,4 @@
-<form class="flex flex-col w-full gap-10 mt-9 mb-15 px-32" id="update-password-form">
+<form class="flex flex-col w-full gap-10 mt-9 mb-10 px-32" id="update-password-form">
     <div class="flex flex-col gap-5">
         <h1 class="font-semibold text-[20px]">Alterar Senha</h1>
         <div class="flex flex-row gap-10">

--- a/src/generic/config/database/TypeOrmConnection.ts
+++ b/src/generic/config/database/TypeOrmConnection.ts
@@ -7,12 +7,12 @@ export default class TypeOrmConnection {
 		if (!dataSource.isInitialized) {
 			console.log("[INFO] 🔌 Establishing database connection");
 
-			await dataSource.initialize().catch((error) => {
-				throw new DatabaseConnectionError(error);
-			});
+			// await dataSource.initialize().catch((error) => {
+			// 	throw new DatabaseConnectionError(error);
+			// });
 
 			console.log("[INFO] 🟢 Database initialized successfully");
-			await CardFlagSeeder.execute(dataSource);
+			// await CardFlagSeeder.execute(dataSource);
 		}
 	}
 }

--- a/src/generic/routes/defaultRouter.ts
+++ b/src/generic/routes/defaultRouter.ts
@@ -32,6 +32,15 @@ defaultRouter.get("/shopping-cart", async (req: Request, res: Response) => {
 	});
 });
 
+defaultRouter.get("/admin", (req: Request, res: Response) => {
+	res.render("", {
+		title: "Admin - Painel de Controle",
+		currentHeaderTab: "admin",
+		layout: "defaultLayoutAdmin",
+		currentUrl: "dashboard"
+	});
+});
+
 defaultRouter.get("/admin/dashboard", async (req: Request, res: Response) => {
 	const books = await bookController.getAll(req, res);
 
@@ -51,9 +60,8 @@ defaultRouter.get("/admin/dashboard", async (req: Request, res: Response) => {
 	res.render("dashboard", {
 		title: "Dashboard - Grafico de linha de vendas",
 		currentHeaderTab: "profile",
-		layout: "detailsLayout",
+		layout: "defaultLayoutAdmin",
 		currentUrl: "dashboard",
-		isAdmin: true,
 		books,
 		labels,
 		salesHistory

--- a/src/generic/routes/defaultRouter.ts
+++ b/src/generic/routes/defaultRouter.ts
@@ -32,15 +32,6 @@ defaultRouter.get("/shopping-cart", async (req: Request, res: Response) => {
 	});
 });
 
-defaultRouter.get("/admin", (req: Request, res: Response) => {
-	res.render("", {
-		title: "Admin - Painel de Controle",
-		currentHeaderTab: "admin",
-		layout: "defaultLayoutAdmin",
-		currentUrl: "dashboard"
-	});
-});
-
 defaultRouter.get("/admin/dashboard", async (req: Request, res: Response) => {
 	const books = await bookController.getAll(req, res);
 

--- a/src/generic/views/components/header.ejs
+++ b/src/generic/views/components/header.ejs
@@ -46,6 +46,13 @@
 					</span>
 				</a>
 			</li>
+			<li>
+				<a class="text-orange hover:text-dark-orange" href="/admin">
+					<span class="material-symbols-outlined">
+					manage_accounts
+					</span>
+				</a>
+			</li>
 		</ul>
 	</div>
 </header>

--- a/src/generic/views/components/header.ejs
+++ b/src/generic/views/components/header.ejs
@@ -47,7 +47,7 @@
 				</a>
 			</li>
 			<li>
-				<a class="text-orange hover:text-dark-orange" href="/admin">
+				<a class="text-orange hover:text-dark-orange" href="/admin/dashboard">
 					<span class="material-symbols-outlined">
 					manage_accounts
 					</span>

--- a/src/generic/views/components/menuBarSide.ejs
+++ b/src/generic/views/components/menuBarSide.ejs
@@ -8,18 +8,6 @@
         </li>
         <li class="py-2">
             <a class="hover:text-gray <%= currentUrl === 'orders' ? 'font-bold' : '' %>" href="/orders">Meus Pedidos</a>
-        </li>
-				<% if (isAdmin) { %>
-					<li class="py-2">
-						<a class="hover:text-gray <%= currentUrl === 'exchange-orders' ? 'font-bold' : '' %>" href="/orders/admin/exchange-orders">Pedidos de Troca</a>
-					</li>
-                    <li class="py-2">
-						<a class="hover:text-gray <%= currentUrl === 'dashboard' ? 'font-bold' : '' %>" href="/admin/dashboard">Dashboard</a>
-					</li>
-                    <li class="py-2">
-						<a class="hover:text-gray <%= currentUrl === 'stock' ? 'font-bold' : '' %>" href="/admin/stock">Estoque</a>
-					</li>
-				<% } %>
         <li class="py-2">
             <a class="hover:text-gray <%= currentUrl === 'coupons' ? 'font-bold' : '' %>" href="/coupons">Meus Cupons</a>
         </li>

--- a/src/generic/views/components/sidebarAdmin.ejs
+++ b/src/generic/views/components/sidebarAdmin.ejs
@@ -1,0 +1,38 @@
+<aside class="h-screen w-64 bg-lighter-brown flex flex-col justify-between py-6 px-5 fixed ">
+    <div>
+        <a href="/" class="flex flex-row items-center gap-2 mb-10">
+            <%- include("mascot.ejs") %>
+            <div class="flex flex-col">
+                <h1 class="font-bold text-light-title text-[20px]">Cozy Shelf</h1>
+                <p class="font-semibold text-light-title text-[14px]">Administrativo</p>
+            </div>
+        </a>
+        <nav>
+            <ul class="text-[16px] space-y-6 divide-y divide-gray-300 text-light-title">
+                <li class="py-2">
+                    <a class="hover:text-light-brown <%= currentUrl === 'dashboard' ? 'font-bold' : '' %>" href="/admin/dashboard">Dashboard</a>
+                </li>
+                <li class="py-2">
+                    <a class="hover:text-light-brown <%= currentUrl === 'clients' ? 'font-bold' : '' %>" href="/clients/admin">Clientes</a>
+                </li>
+                <li class="py-2">
+                    <a class="hover:text-light-brown <%= currentUrl === 'orders' ? 'font-bold' : '' %>" href="/orders/admin">Pedidos</a>
+                </li>
+                <li class="py-2">
+                    <a class="hover:text-light-brown <%= currentUrl === 'exchange-orders' ? 'font-bold' : '' %>" href="/orders/admin/exchange-orders">Pedidos de troca</a>
+                </li>
+                <li class="py-2">
+                    <a class="hover:text-light-brown <%= currentUrl === 'stock' ? 'font-bold' : '' %>" href="/admin/stock">Estoque</a>
+                </li>
+            </ul>
+            <div class="py-55">
+                <a class="flex items-center gap-2 text-[14px] text-light-title hover:text-light-brown" href="/">
+                    <span class="material-symbols-outlined">
+                        arrow_back
+                    </span>
+                    Volte para o site
+                </a>
+            </div>
+        </nav>
+    </div>    
+</aside>

--- a/src/generic/views/layouts/defaultLayoutAdmin.ejs
+++ b/src/generic/views/layouts/defaultLayoutAdmin.ejs
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<link
+		href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap"
+		rel="stylesheet">
+	<script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
+	<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+	<link href="https://fonts.googleapis.com/icon?family=Material+Symbols+Outlined" rel="stylesheet">
+	<link rel="stylesheet" href="/styles/output.css">
+	<title>Cozyshelf Admin - <%- title %></title>
+</head>
+
+<body class="font-default">
+	<div class="flex flex-col wrapper min-h-screen">
+		<%- include('sidebarAdmin.ejs') %>
+            <main class="flex-grow ml-64 p-8"><%- body %></main>
+    </div>
+</body>
+
+</html>

--- a/src/order/router/orderRouter.ts
+++ b/src/order/router/orderRouter.ts
@@ -22,9 +22,9 @@ orderRouter.get("/", (req: Request, res: Response) => {
 
 orderRouter.get("/admin", (req: Request, res: Response) => {
 	res.render("ordersTable", {
-		title: "Meus Pedidos",
+		title: "Pedidos",
 		currentHeaderTab: "profile",
-		layout: "detailsLayout",
+		layout: "defaultLayoutAdmin",
 		currentUrl: "orders",
 		isAdmin: true
 	});
@@ -34,9 +34,8 @@ orderRouter.get("/admin/exchange-orders", (req: Request, res: Response) => {
 	res.render("exchangeOrdersTable", {
 		title: "Pedidos de Troca",
 		currentHeaderTab: "profile",
-		layout: "detailsLayout",
+		layout: "defaultLayoutAdmin",
 		currentUrl: "exchange-orders",
-		isAdmin: true,
 	});
 });
 
@@ -58,7 +57,7 @@ orderRouter.get("/admin/:id", async (req: Request, res: Response) => {
 	res.render("orderDetails", {
 		title: "Detalhes do Pedido",
 		currentHeaderTab: "profile",
-		layout: "detailsLayout",
+		layout: "defaultLayoutAdmin",
 		isNewOrder: false,
 		books: books,
 		currentUrl: "orders",

--- a/src/order/views/exchangeOrdersTable.ejs
+++ b/src/order/views/exchangeOrdersTable.ejs
@@ -16,7 +16,7 @@
 				<td class="px-6 py-3 font-medium text-gray-2">12413113123123</td>
 				<td class="px-6 py-3">12413113123123</td>
 				<td class="px-6 py-3">
-					<button class="cursor-pointer" id="confirmExchange">
+					<button class="cursor-pointer flex px-7" id="confirmExchange">
 						<span class="material-symbols-outlined text-light-green">
 							check
 						</span>
@@ -27,7 +27,7 @@
 				<td class="px-6 py-3 font-medium text-gray-2">12413153142123</td>
 				<td class="px-6 py-3">12413123523623</td>
 				<td class="px-6 py-3">
-					<button class="cursor-pointer" id="confirmExchange">
+					<button class="cursor-pointer flex px-7" id="confirmExchange">
 						<span class="material-symbols-outlined text-light-green">
 							check
 						</span>

--- a/src/order/views/orderDetails.ejs
+++ b/src/order/views/orderDetails.ejs
@@ -58,36 +58,39 @@
                 <div class="flex flex-col gap-4">
                     <% books.forEach(function(book) { %>
                         <div class="flex gap-4">
-													<img src="<%= book.coverPath %>" alt="Capa do livro <%= book.name %>" class="w-16 h-20 object-cover rounded">
-													<div class="flex flex-col justify-between">
-														<h2 class="font-semibold text-[14px]"><%= book.name %></h2>
-														<div class="flex items-center justify-between gap-15">
-																<p class="text-gray-dark text-[12px]">Quantidade: 1</p>
-																<p class="font-semibold text-brown text-[14px]">R$ <%= book.price.toFixed(2).replace('.', ',') %></p>
-														</div>
-													</div>
+                            <img src="<%= book.coverPath %>" alt="Capa do livro <%= book.name %>" class="w-16 h-20 object-cover rounded">
+                            <div class="flex flex-col justify-between">
+                                <h2 class="font-semibold text-[14px]"><%= book.name %></h2>
+                                <div class="flex items-center justify-between gap-15">
+                                        <p class="text-gray-dark text-[12px]">Quantidade: 1</p>
+                                        <p class="font-semibold text-brown text-[14px]">R$ <%= book.price.toFixed(2).replace('.', ',') %></p>
+                                </div>
+                            </div>
                         </div>
                     <% }); %>
                 </div>
             </div>
         </div>
         <div class="flex flex-row justify-between items-center mt-4">
-            <a href="/orders" class="font-semibold text-sm bg-brown text-white rounded hover:bg-dark-brown w-[150px] h-10 flex items-center justify-center">
-            Voltar
+            <a 
+                href="<%= isAdmin ? '/orders/admin' : '/orders' %>" 
+                class="font-semibold text-sm bg-brown text-white rounded hover:bg-dark-brown w-[150px] h-10 flex items-center justify-center"
+            >
+                Voltar
             </a>
-						<% if (!isAdmin) { %>
-							<button type="submit" class="font-semibold text-sm bg-orange text-white rounded hover:bg-dark-orange w-[150px] h-10 flex items-center justify-center">
-									Pedir Troca
-							</button>
-						<% } %>
-						<% if (isAdmin) { %>
-							<button type="submit" class="font-semibold text-sm bg-light-brown text-white rounded hover:bg-light-title w-[150px] h-10 flex items-center justify-center">
-									Solicitar Entrega
-							</button>
-							<button type="submit" class="font-semibold text-sm bg-light-green text-white rounded hover:bg-dark-green w-[150px] h-10 flex items-center justify-center">
-									Confirmar Entrega
-							</button>
-						<% } %>
+            <% if (!isAdmin) { %>
+                <button type="submit" class="font-semibold text-sm bg-orange text-white rounded hover:bg-dark-orange w-[150px] h-10 flex items-center justify-center">
+                        Pedir Troca
+                </button>
+            <% } %>
+            <% if (isAdmin) { %>
+                <button type="submit" class="font-semibold text-sm bg-light-brown text-white rounded hover:bg-light-title w-[150px] h-10 flex items-center justify-center">
+                        Solicitar Entrega
+                </button>
+                <button type="submit" class="font-semibold text-sm bg-light-green text-white rounded hover:bg-dark-green w-[150px] h-10 flex items-center justify-center">
+                        Confirmar Entrega
+                </button>
+            <% } %>
         </div>
     </div>
 </form>

--- a/src/order/views/ordersTable.ejs
+++ b/src/order/views/ordersTable.ejs
@@ -1,6 +1,6 @@
 <div class="flex flex-col w-full gap-10 mt-9 mb-15 px-32">
 	<div class="flex justify-between align-middle">
-		<h1 class="font-semibold text-[20px]">Meus Pedidos (2)</h1>
+		<h1 class="font-semibold text-[20px]"><%= title %> (2)</h1>
 		<div class="flex items-center gap-2">
 			<h1 class="text-gray">Filtrar: </h1>
             <select class="border border-gray rounded-md px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-dark-brown">

--- a/src/stock/router/orderRouter.ts
+++ b/src/stock/router/orderRouter.ts
@@ -16,12 +16,10 @@ stockRouter.get("/", async (req: Request, res: Response) => {
 	res.render("stockTable", {
 		title: "Estoque",
 		currentHeaderTab: "profile",
-		layout: "detailsLayout",
+		layout: "defaultLayoutAdmin",
 		currentUrl: "stock",
-		isAdmin: true,
 		books: books
 	});
 });
-
 
 export default stockRouter;

--- a/src/stock/views/stockTable.ejs
+++ b/src/stock/views/stockTable.ejs
@@ -1,6 +1,6 @@
 <div class="flex flex-col w-full gap-10 mt-9 mb-15 px-32">
 	<div class="flex justify-between align-middle">
-		<h1 class="font-semibold text-[20px]">Estoque</h1>
+		<h1 class="font-semibold text-[20px]">Estoque (6)</h1>
 		<div class="flex items-center gap-2">
 			<h1 class="text-gray">Filtrar: </h1>
             <select class="border border-gray rounded-md px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-dark-brown">
@@ -19,7 +19,7 @@
 				<th class="px-6 py-3 text-left font-semibold">Ações</th>
 			</tr>
 		</thead>
-		<tbody class="divide-y divide-light-brown text-sm text-gray-2 bg-lighter-brown">
+		<tbody class="divide-y divide-light-brown text-sm text-gray-2 bg-lighter-brown justify-centers">
 			<% books.forEach(function(book) { %>
 				<tr>
 					<td class="px-6 py-3 font-medium text-gray-2"><%= book.id %></td>
@@ -28,14 +28,14 @@
 						<span><%= book.name %></span>
 					</td>
 					<td class="px-6 py-3">
-						<div class="flex items-center gap-2 ml-4 w-28 justify-center">
+						<div class="flex items-center gap-2 w-28 ">
 							<button type="button" class="px-2 py-1 text-xs bg-gray-200 rounded hover:bg-gray-3" title="Diminuir quantidade">-</button>
 							<input type="text" value="<%= book.quantity || 1 %>" class="w-8 text-center border rounded text-[12px] bg-white" readonly>
 							<button type="button" class="px-2 py-1 text-xs bg-gray-200 rounded hover:bg-gray-3" title="Aumentar quantidade">+</button>
 						</div>
 					</td>
-					<td class="px-6 py-3 flex gap-2">
-						<button type="button" class="hover:text-gray flex justify-center items-center" title="Bloquear">
+					<td class="px-6 py-3">
+						<button type="button" class="hover:text-gray flex px-4" title="Bloquear">
 							<span class="material-symbols-outlined text-base">block</span>
 						</button>
 					</td>


### PR DESCRIPTION
This pull request introduces a new admin layout and navigation system for the application, refactors routing and view logic to support admin-specific pages. The changes enhance the separation between regular user and admin experiences, add a sidebar for admin navigation, and update the existed views for consistency and usability.

### Admin Layout & Navigation
<img width="650" height="450" alt="image" src="https://github.com/user-attachments/assets/fe82848a-c97b-4932-b1cb-70cf5ed7b322" />

* Added a new `defaultLayoutAdmin.ejs` layout and `sidebarAdmin.ejs` component for a dedicated admin interface, including improved navigation links for dashboard, clients, orders, exchange orders, and stock management.
* Updated routes for admin pages (`/admin/dashboard`, `/clients/admin`, `/orders/admin`, `/admin/stock`, etc.) to use the new admin layout.



These changes collectively provide a better admin and user experience, and improve the maintainability of the codebase.